### PR TITLE
Fix incorrect call in the docs

### DIFF
--- a/lib/Text/FileTree.pm
+++ b/lib/Text/FileTree.pm
@@ -118,7 +118,7 @@ sub from_file {
 Load the file list from a filehandle (or a filename). Examples:
 
  open(my $pipe, '-|', 'find', '/');
- Text::FileTree::from_fh($pipe);
+ Text::FileTree->new->from_fh($pipe);
 
 =cut
 


### PR DESCRIPTION
The way the docs currently say to call `from_fh` doesn't work, since it's expecting `Text::FileTree` object as the first argument.
