### PR TITLE
Allow for arrayref to be passed to ->parse

### DIFF
--- a/lib/Text/FileTree.pm
+++ b/lib/Text/FileTree.pm
@@ -80,6 +80,11 @@ sub new {
 sub parse {
 	my $self = shift;
 
+	if(ref $_[0] eq 'ARRAY') {
+		my $ref = shift @_;
+		push(@_, @{ $ref });
+	}
+
 	for my $str (@_) {
 		$self->__parse_file($_) for split /\n/, $str;
 	}


### PR DESCRIPTION
Allow for arguments to `->parse` to be passed as not just a flat list, but also as an arrayref:

```perl
my $refeliref = ['foo/bar/baz.mp3', 'foo/bar/laleh.flac'];
p $tree->parse($refeliref);
```

```
{
    foo   {
        bar   {
            baz.mp3      {},
            laleh.flac   {}
        }
    }
}
```


